### PR TITLE
Feat: Allow trino authen user with ranger-groups

### DIFF
--- a/plugin-trino/conf/ranger-trino-security.xml
+++ b/plugin-trino/conf/ranger-trino-security.xml
@@ -71,4 +71,12 @@
       S3 Plugin RangerRestClient read Timeout in Milli Seconds
     </description>
   </property>
+
+  <property>
+      <name>ranger.plugin.trino.use.rangerGroups</name>
+      <value>true</value>
+      <description>
+          Ranger policies using user-groups from Ranger admin
+      </description>
+  </property>
 </configuration>

--- a/plugin-trino/src/test/resources/ranger-trino-security.xml
+++ b/plugin-trino/src/test/resources/ranger-trino-security.xml
@@ -49,4 +49,11 @@
         </description>
     </property>
 
+    <property>
+        <name>ranger.plugin.trino.use.rangerGroups</name>
+        <value>true</value>
+        <description>
+            Ranger policies using user-groups from Ranger admin
+        </description>
+    </property>
 </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow trino authen user with ranger-groups instead of trino-groups:

- ranger-groups: Group that the user belong to in the ranger security admin. (ex synced via ranger-usersync).
- trino-groups: Group that the user belong to in the trino deployment (config via config file, docs: **https://trino.io/docs/current/develop/group-provider.html**).


## How was this patch tested?

manual test