### PR TITLE
feat(ranger): allow dynamic Ranger Admin heap size

### DIFF
--- a/embeddedwebserver/scripts/ranger-admin-services.sh
+++ b/embeddedwebserver/scripts/ranger-admin-services.sh
@@ -32,7 +32,7 @@ XAPOLICYMGR_DIR=`(cd $realScriptDir/..; pwd)`
 XAPOLICYMGR_EWS_DIR=${XAPOLICYMGR_DIR}/ews
 RANGER_JAAS_LIB_DIR="${XAPOLICYMGR_EWS_DIR}/ranger_jaas"
 RANGER_JAAS_CONF_DIR="${XAPOLICYMGR_EWS_DIR}/webapp/WEB-INF/classes/conf/ranger_jaas"
-ranger_admin_max_heap_size=1g
+ranger_admin_max_heap_size=${RANGER_ADMIN_MAX_HEAP_SIZE:-1g}
 
 if [ -f ${XAPOLICYMGR_DIR}/ews/webapp/WEB-INF/classes/conf/java_home.sh ]; then
         . ${XAPOLICYMGR_DIR}/ews/webapp/WEB-INF/classes/conf/java_home.sh


### PR DESCRIPTION
## What changes were proposed in this pull request?

Dynamic set ranger admin heap size via environment variable.

https://atlassiansuite.mservice.com.vn:8443/browse/DG-321


## How was this patch tested?

No test.