### PR TITLE
Bump Trino version to 461

### DIFF
--- a/.github/workflows/maven-trino.yml
+++ b/.github/workflows/maven-trino.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 23
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '23'
         distribution: 'temurin'
         cache: maven
     - name: Verify with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -22,7 +22,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Java CI with Maven
+name: Java CI with Maven for Security Admin
 
 on:
   push:
@@ -44,4 +44,4 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build and Package with Maven
-      run: mvn -B clean package -DskipTests
+      run: mvn -B clean verify -P ranger-admin,'!all','!linux' 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,10 +37,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 17
+    - name: Set up JDK 23
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '23'
         distribution: 'temurin'
         cache: maven
     - name: Build and Package with Maven

--- a/dev-support/ranger-docker/Dockerfile.mm-ranger
+++ b/dev-support/ranger-docker/Dockerfile.mm-ranger
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:17.0.9_9-jdk-focal AS ranger_base
+FROM eclipse-temurin:23_37-jdk-noble AS ranger_base
 
 # Install tzdata, Python, Java, python-requests
 RUN apt-get update && \
     DEBIAN_FRONTEND="noninteractive" apt-get -y install python3 python3-pip bc apt-transport-https && \
-    pip3 install --no-cache-dir apache-ranger requests && \
+    pip3 install --no-cache-dir apache-ranger requests --break-system-packages && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/dev-support/ranger-docker/Dockerfile.ranger-trino
+++ b/dev-support/ranger-docker/Dockerfile.ranger-trino
@@ -22,7 +22,7 @@ ARG RANGER_VERSION
 
 USER root
 # install sudo and allow trino user to use sudo without password
-RUN apt-get update && apt-get install -y sudo && apt-get clean && echo 'trino ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN microdnf update && microdnf install -y sudo && microdnf clean all && echo 'trino ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 COPY ./dist/${RANGER_VERSION}.tar.gz /etc/trino
 COPY ./scripts/trino/install.properties /etc/trino

--- a/dev-support/ranger-docker/docker-compose.ranger-trino.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger-trino.yml
@@ -6,8 +6,8 @@ services:
       dockerfile: Dockerfile.ranger-trino
       args:
         - RANGER_VERSION=ranger-3.0.0-SNAPSHOT-trino-plugin
-        - TRINO_VERSION=${TRINO_VERSION:-431}
-    image: ranger-trino:${TRINO_VERSION:-431}
+        - TRINO_VERSION=${TRINO_VERSION:-461}
+    image: ranger-trino:${TRINO_VERSION:-461}
     hostname: ranger-trino
     container_name: ranger-trino
     stdin_open: true

--- a/dev-support/ranger-docker/docker-compose.ranger.yml
+++ b/dev-support/ranger-docker/docker-compose.ranger.yml
@@ -40,6 +40,7 @@ services:
       - RANGER_TAGRSYNC_PASSWORD=rangerR0cks!
       - RANGER_USERSYNC_PASSWORD=rangerR0cks!
       - RANGER_KEYADMIN_PASSWORD=rangerR0cks!
+      - RANGER_ADMIN_MAX_HEAP_SIZE=2g
 
     command:
       - /home/ranger/scripts/ranger.sh

--- a/hdfs-agent/pom.xml
+++ b/hdfs-agent/pom.xml
@@ -180,7 +180,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.0.2</version>
                 <configuration>
                     <archive>
                         <index>true</index>

--- a/plugin-trino/pom.xml
+++ b/plugin-trino/pom.xml
@@ -24,7 +24,7 @@
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <javac.target.version>17</javac.target.version>
+        <javac.target.version>23</javac.target.version>
     </properties>
     <parent>
         <groupId>org.apache.ranger</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -837,7 +837,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
-                        <version>3.5.0</version>
+                        <version>3.0.0-M3</version>
                         <executions>
                             <execution>
                                 <id>enforce-maven</id>
@@ -1096,7 +1096,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.0.0-M3</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <apacheds.version>2.0.0-M22</apacheds.version>
         <asm.all.version>3.2</asm.all.version>
         <aspectj.version>1.8.2</aspectj.version>
-        <assembly.plugin.version>2.6</assembly.plugin.version>
+        <assembly.plugin.version>3.7.1</assembly.plugin.version>
         <atlas.version>2.2.0</atlas.version>
         <atlas.jackson.version>2.11.3</atlas.jackson.version>
         <atlas.jackson.databind.version>2.11.3</atlas.jackson.databind.version>
@@ -185,7 +185,7 @@
         <owasp-java-html-sanitizer.version>20211018.2</owasp-java-html-sanitizer.version>
         <paranamer.version>2.3</paranamer.version>
         <presto.version>333</presto.version>
-        <trino.version>431</trino.version>
+        <trino.version>461</trino.version>
         <poi.version>5.2.2</poi.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <protobuf-java.version>3.19.3</protobuf-java.version>
@@ -324,8 +324,8 @@
                 <module>plugin-schema-registry</module>
                 <module>plugin-sqoop</module>
                 <module>ranger-sqoop-plugin-shim</module>
-                <module>plugin-kylin</module>
-                <module>ranger-kylin-plugin-shim</module>
+                <!-- <module>plugin-kylin</module>
+                <module>ranger-kylin-plugin-shim</module> -->
                 <module>plugin-elasticsearch</module>
                 <module>ranger-elasticsearch-plugin-shim</module>
                 <!--
@@ -837,7 +837,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-enforcer-plugin</artifactId>
-                        <version>1.4.1</version>
+                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>enforce-maven</id>
@@ -1096,7 +1096,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>enforce-versions</id>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <eclipse.jpa.version>2.7.12</eclipse.jpa.version>
         <elasticsearch.version>7.10.2</elasticsearch.version>
         <enunciate.version>2.17.1</enunciate.version>
-        <spotbugs.plugin.version>4.7.3.5</spotbugs.plugin.version>
+        <spotbugs.plugin.version>4.8.6.4</spotbugs.plugin.version>
         <google.guava.version>27.0-jre</google.guava.version>
         <googlecode.log4jdbc.version>1.2</googlecode.log4jdbc.version>
         <graalvm.version>22.3.0</graalvm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1010,7 +1010,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.surefire.plugin.version}</version>
                     <configuration>
-                        <argLine>${argLine} -Djava.library.path="${hadoop.library.path}${path.separator}${java.library.path}"</argLine>
+                        <argLine>${argLine} -Djava.security.manager=allow -Djava.library.path="${hadoop.library.path}${path.separator}${java.library.path}"</argLine>
                         <skipTests>${skipTests}</skipTests>
                         <encoding>UTF-8</encoding>
                         <systemProperties>

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
         <google.cloud.kms>2.3.0</google.cloud.kms>
 
         <!-- JaCoCo Properties -->
-        <jacoco.version>0.8.7</jacoco.version>
+        <jacoco.version>0.8.12</jacoco.version>
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
         <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
         <sonar.language>java</sonar.language>

--- a/security-admin/pom.xml
+++ b/security-admin/pom.xml
@@ -1164,7 +1164,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>duplicate-sql-patch-file-version-validator</id>

--- a/security-admin/pom.xml
+++ b/security-admin/pom.xml
@@ -1164,7 +1164,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.0.0-M3</version>
                 <executions>
                     <execution>
                         <id>duplicate-sql-patch-file-version-validator</id>


### PR DESCRIPTION
Bump Trino version to 461:

- Build with JDK23
- Remove plugin-kylin due to compile error: kylin's dependency does not support JDK23. 